### PR TITLE
README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Assuming that:
 
 Run this docker image e.g. like this:
 ```bash
-$ docker run -dti --name berks -v ${PWD}/test/berkshelf.pem:/home/berkshelf/.chef/berkshelf.pem -e CHEF_SERVER_ENDPOINT="https://chef.example.com:443" -e BERKS_BUILD_INTERVAL=15 -e CHEF_ORGANIZATION="/organizations/testorg" --link chef_server:chef.example.com -p 26200:26200  xmik/berkshelf-api-docker:0.0.4
+$ docker run -dti --name berks -v ${PWD}/test/berkshelf.pem:/home/berkshelf/.chef/berkshelf.pem -e CHEF_SERVER_ENDPOINT="https://chef.example.com:443" -e BERKS_BUILD_INTERVAL=15 -e CHEF_ORGANIZATION="/organizations/testorg" --link chef_server:chef.example.com -p 26200:26200  hrak/berkshelf-api-docker:0.0.4
 ```
 
 where:


### PR DESCRIPTION
The `docker run` example was referencing `xmik` repo instead of this repo `hrak`.